### PR TITLE
Valueset and Codesystem update for Signal regions

### DIFF
--- a/input/vocabulary/codesystem-signal-region.json
+++ b/input/vocabulary/codesystem-signal-region.json
@@ -19,11 +19,11 @@
     "concept": [
         {
             "code": "SSPA1",
-            "display": "SSPA 1 : Northeast Colorado (Signal)"
+            "display": "SSPA 1 : Northeast Colorado"
         },
         {
             "code": "SSPA2",
-            "display": "SSPA 2 : Metro Denver (Signal)"
+            "display": "SSPA 2 : Metro Denver"
         },
         {
             "code": "SSPA3",
@@ -31,7 +31,7 @@
         },
         {
             "code": "SSPA4",
-            "display": "SSPA 4 : Southeastern Colorado including San Luis Valley (Signal)"
+            "display": "SSPA 4 : Southeastern Colorado including San Luis Valley"
         },
         {
             "code": "SSPA5",

--- a/input/vocabulary/valueset-signal-region.json
+++ b/input/vocabulary/valueset-signal-region.json
@@ -19,11 +19,11 @@
                 "concept": [
                     {
                         "code": "SSPA1",
-                        "display": "SSPA 1 : Northeast Colorado (Signal)"
+                        "display": "SSPA 1 : Northeast Colorado"
                     },
                     {
                         "code": "SSPA2",
-                        "display": "SSPA 2 : Metro Denver (Signal)"
+                        "display": "SSPA 2 : Metro Denver"
                     },
                     {
                         "code": "SSPA3",
@@ -31,7 +31,7 @@
                     },
                     {
                         "code": "SSPA4",
-                        "display": "SSPA 4 : Southeastern Colorado including San Luis Valley (Signal)"
+                        "display": "SSPA 4 : Southeastern Colorado including San Luis Valley"
                     },
                     {
                         "code": "SSPA5",
@@ -71,12 +71,12 @@
             {
                 "system": "https://signalbhn.org/fhir/CodeSystem/signal-region",
                 "code": "SSPA1",
-                "display": "SSPA 1 : Northeast Colorado (Signal)"
+                "display": "SSPA 1 : Northeast Colorado"
             },
             {
                 "system": "https://signalbhn.org/fhir/CodeSystem/signal-region",
                 "code": "SSPA2",
-                "display": "SSPA 2 : Metro Denver (Signal)"
+                "display": "SSPA 2 : Metro Denver"
             },
             {
                 "system": "https://signalbhn.org/fhir/CodeSystem/signal-region",
@@ -86,7 +86,7 @@
             {
                 "system": "https://signalbhn.org/fhir/CodeSystem/signal-region",
                 "code": "SSPA4",
-                "display": "SSPA 4 : Southeastern Colorado including San Luis Valley (Signal)"
+                "display": "SSPA 4 : Southeastern Colorado including San Luis Valley"
             },
             {
                 "system": "https://signalbhn.org/fhir/CodeSystem/signal-region",


### PR DESCRIPTION
Removed the word "(signal)" from Signal regions drop downs (VS and CS) as per the Change request requested from signal. Kindly approve @arunsundar-m 